### PR TITLE
Add the ability to specify ffmpeg path & use Matplotlib's ffmpeg path

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,3 +458,37 @@ with Loom("parallel_sine_wave.gif", fps=30, parallel=True) as loom:
         for i, phase in enumerate(phases)
     )
 ```
+
+Providing a Custom FFmpeg Path
+------------------------------
+
+matplotloom supports providing custom FFmpeg path via three methods
+
+1. Set the matplotlib ``animation.ffmpeg_args`` [rcPrams](https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.rcParams) to the custom FFmpeg path 
+    * This is the default path matplotloom attempts to use
+2. Set the Environment Variable ``LOOM_FFMPEG_PATH`` to the custom FFmpeg path
+3. Pass the custom FFmpeg path as the ``ffmpeg_path`` argument when creating a ``Loom``
+
+```python
+ # Either the environ var OR matplotlib rcPram *needs* to be set BEFORE
+ #  importing matplotloom
+ import imageio_ffmpeg # A python library that provides an ffmpeg binary 
+ FFMPEG_PATH: str = imageio_ffmpeg.get_ffmpeg_exe()
+
+ # Configure matplotlib rcPrams, if your global / project rcPrams file
+ #  already sets this then you don't need to overload it. 
+ plt.rcParams['animation.ffmpeg_path'] = FFMPEG_PATH
+
+
+ # Alternatively could set the environment variable however this *does not*
+ #  inform matplotlib there is a valid ffmpeg binary so should be avoided.
+ #  The intention is to allow any more complex toolchains the option if needed.
+ import os
+ os.environ["LOOM_FFMPEG_PATH"] = FFMPEG_PATH
+
+
+ # Import Matplotloom once the path has been set
+ from matplotloom import Loom
+
+ # ...
+ ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -468,6 +468,42 @@ By passing ``parallel=True`` when creating a ``Loom``, you can save frames using
             for i, phase in enumerate(phases)
         )
 
+Providing a Custom FFmpeg Path
+------------------------------
+
+matplotloom supports providing custom FFmpeg path via three methods
+
+1. Set the matplotlib ``animation.ffmpeg_args`` `rcPrams`_ to the custom FFmpeg path 
+    * This is the default path matplotloom attempts to use
+2. Set the Environment Variable ``LOOM_FFMPEG_PATH`` to the custom FFmpeg path
+3. Pass the custom FFmpeg path as the ``ffmpeg_path`` argument when creating a ``Loom``
+
+.. _rcPrams: https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.rcParams
+
+.. code-block:: python
+    
+    # Either the environ var OR matplotlib rcPram *needs* to be set BEFORE
+    #  importing matplotloom
+    import imageio_ffmpeg # A python library that provides an ffmpeg binary 
+    FFMPEG_PATH: str = imageio_ffmpeg.get_ffmpeg_exe()
+
+    # Configure matplotlib rcPrams, if your global / project rcPrams file
+    #  already sets this then you don't need to overload it. 
+    plt.rcParams['animation.ffmpeg_path'] = FFMPEG_PATH
+
+
+    # Alternatively could set the environment variable however this *does not*
+    #  inform matplotlib there is a valid ffmpeg binary so should be avoided.
+    #  The intention is to allow any more complex toolchains the option if needed.
+    import os
+    os.environ["LOOM_FFMPEG_PATH"] = FFMPEG_PATH
+
+
+    # Import Matplotloom once the path has been set
+    from matplotloom import Loom
+
+    # ...
+
 Reference
 ---------
 

--- a/examples/custom_ffmpeg_sine_wave.py
+++ b/examples/custom_ffmpeg_sine_wave.py
@@ -1,0 +1,41 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from joblib import Parallel, delayed
+
+# Either the environ var OR matplotlib rcPram *needs* to be set BEFORE
+#  importing matplotloom
+import imageio_ffmpeg # python library that provides ffmpeg binary 
+FFMPEG_PATH: str = imageio_ffmpeg.get_ffmpeg_exe()
+
+# Configure matplotlib rcPrams, if your global / project rcPrams file
+#  already sets this then you don't need to overload it. 
+plt.rcParams['animation.ffmpeg_path'] = FFMPEG_PATH
+
+# Alternatively could set the environment variable however this *does not*
+#  inform matplotlib there is a valid ffmpeg binary so should be avoided.
+#  The intention is to allow any more complex toolchains the option if needed.
+# import os
+#os.environ["LOOM_FFMPEG_PATH"] = FFMPEG_PATH
+
+from matplotloom import Loom
+
+def plot_frame(phase, frame_number, loom):
+    fig, ax = plt.subplots()
+
+    x = np.linspace(0, 2*np.pi, 200)
+    y = np.sin(x + phase)
+    
+    ax.plot(x, y)
+    ax.set_xlim(0, 2*np.pi)
+    
+    loom.save_frame(fig, frame_number)
+
+with Loom("custom_parallel_sine_wave.gif", fps=30, parallel=True) as loom:
+    phases = np.linspace(0, 2*np.pi, 100)
+    
+    Parallel(n_jobs=-1)(
+        delayed(plot_frame)(phase, i, loom) 
+        for i, phase in enumerate(phases)
+    )
+

--- a/examples/parallel_sine_wave.py
+++ b/examples/parallel_sine_wave.py
@@ -3,21 +3,6 @@ import matplotlib.pyplot as plt
 
 from joblib import Parallel, delayed
 
-# Either the environ var OR matplotlib rcPram *needs* to be set BEFORE
-#  importing matplotloom
-import imageio_ffmpeg # python library that provides ffmpeg binary 
-FFMPEG_PATH: str = imageio_ffmpeg.get_ffmpeg_exe()
-
-# Configure matplotlib rcPrams, if your global / project rcPrams file
-#  already sets this then you don't need to overload it. 
-plt.rcParams['animation.ffmpeg_path'] = FFMPEG_PATH
-
-# Alternatively could set the environment variable however this *does not*
-#  inform matplotlib there is a valid ffmpeg binary so should be avoided.
-#  The intention is to allow any more complex toolchains the option if needed.
-# import os
-#os.environ["LOOM_FFMPEG_PATH"] = FFMPEG_PATH
-
 from matplotloom import Loom
 
 def plot_frame(phase, frame_number, loom):

--- a/examples/parallel_sine_wave.py
+++ b/examples/parallel_sine_wave.py
@@ -2,6 +2,22 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from joblib import Parallel, delayed
+
+# Either the environ var OR matplotlib rcPram *needs* to be set BEFORE
+#  importing matplotloom
+import imageio_ffmpeg # python library that provides ffmpeg binary 
+FFMPEG_PATH: str = imageio_ffmpeg.get_ffmpeg_exe()
+
+# Configure matplotlib rcPrams, if your global / project rcPrams file
+#  already sets this then you don't need to overload it. 
+plt.rcParams['animation.ffmpeg_path'] = FFMPEG_PATH
+
+# Alternatively could set the environment variable however this *does not*
+#  inform matplotlib there is a valid ffmpeg binary so should be avoided.
+#  The intention is to allow any more complex toolchains the option if needed.
+# import os
+#os.environ["LOOM_FFMPEG_PATH"] = FFMPEG_PATH
+
 from matplotloom import Loom
 
 def plot_frame(phase, frame_number, loom):

--- a/matplotloom/__init__.py
+++ b/matplotloom/__init__.py
@@ -38,7 +38,7 @@ if not _check_ffmpeg_availability() and current_process().name == 'MainProcess':
         " is set to a valid ffmpeg executable or configure "
         "`matplotlib.pyplot.rcParams['animation.ffmpeg_path']` to point to an "
         "ffmpeg executable. The current command used to run ffmpeg "
-        f"is `{DEFAULT_FFMPEG_PATH}`",
+        f"is: `{DEFAULT_FFMPEG_PATH}`",
         UserWarning,
         stacklevel=2
     )

--- a/matplotloom/__init__.py
+++ b/matplotloom/__init__.py
@@ -3,7 +3,7 @@ import shutil
 import warnings
 from multiprocessing import current_process
 
-from .loom import Loom, DEFAULT_FFMPEG_PATH
+from .loom import Loom, DEFAULT_FFMPEG_PATH, _LOOM_DEFAULT_ENVIRON_VAR
 
 __version__ = "0.9.2"
 __all__ = ["Loom"]
@@ -34,8 +34,10 @@ if not _check_ffmpeg_availability() and current_process().name == 'MainProcess':
         "matplotloom requires ffmpeg to create animations. "
         "Please install ffmpeg to use this library. "
         "Visit https://ffmpeg.org/download.html for installation instructions. "
-        "Or configure `matplotlib.pyplot.rcParams['animation.ffmpeg_path']` to "
-        "point to an ffmpeg executable. The current command used to run ffmpeg "
+        f"Optionally ensure the environment variable `{_LOOM_DEFAULT_ENVIRON_VAR}`"
+        " is set to a valid ffmpeg executable or configure "
+        "`matplotlib.pyplot.rcParams['animation.ffmpeg_path']` to point to an "
+        "ffmpeg executable. The current command used to run ffmpeg "
         f"is `{DEFAULT_FFMPEG_PATH}`",
         UserWarning,
         stacklevel=2

--- a/matplotloom/__init__.py
+++ b/matplotloom/__init__.py
@@ -2,9 +2,9 @@ import subprocess
 import shutil
 import warnings
 
-from .loom import Loom
+from .loom import Loom, DEFAULT_FFMPEG_PATH
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 __all__ = ["Loom"]
 
 
@@ -12,12 +12,12 @@ def _check_ffmpeg_availability():
     """Check if ffmpeg is available on the system."""
     try:
         # more reliable cross-platform
-        if shutil.which("ffmpeg") is not None:
+        if shutil.which(DEFAULT_FFMPEG_PATH) is not None:
             return True
 
         # Fallback: try running ffmpeg with subprocess
         subprocess.run(
-            ["ffmpeg", "-version"],
+            [DEFAULT_FFMPEG_PATH, "-version"],
             capture_output=True,
             check=True,
             timeout=5
@@ -32,7 +32,10 @@ if not _check_ffmpeg_availability():
         "ffmpeg is not available on your system. "
         "matplotloom requires ffmpeg to create animations. "
         "Please install ffmpeg to use this library. "
-        "Visit https://ffmpeg.org/download.html for installation instructions.",
+        "Visit https://ffmpeg.org/download.html for installation instructions."
+        "Or configure `matplotlib.pyplot.rcParams['animation.ffmpeg_path']` to "
+        "point to an ffmpeg executable. The current command used to run ffmpeg "
+        f"is `{DEFAULT_FFMPEG_PATH}`",
         UserWarning,
         stacklevel=2
     )

--- a/matplotloom/__init__.py
+++ b/matplotloom/__init__.py
@@ -1,6 +1,7 @@
 import subprocess
 import shutil
 import warnings
+from multiprocessing import current_process
 
 from .loom import Loom, DEFAULT_FFMPEG_PATH
 
@@ -27,7 +28,7 @@ def _check_ffmpeg_availability():
         return False
 
 
-if not _check_ffmpeg_availability():
+if not _check_ffmpeg_availability() and current_process().name == 'MainProcess':
     warnings.warn(
         "ffmpeg is not available on your system. "
         "matplotloom requires ffmpeg to create animations. "

--- a/matplotloom/__init__.py
+++ b/matplotloom/__init__.py
@@ -33,7 +33,7 @@ if not _check_ffmpeg_availability() and current_process().name == 'MainProcess':
         "ffmpeg is not available on your system. "
         "matplotloom requires ffmpeg to create animations. "
         "Please install ffmpeg to use this library. "
-        "Visit https://ffmpeg.org/download.html for installation instructions."
+        "Visit https://ffmpeg.org/download.html for installation instructions. "
         "Or configure `matplotlib.pyplot.rcParams['animation.ffmpeg_path']` to "
         "point to an ffmpeg executable. The current command used to run ffmpeg "
         f"is `{DEFAULT_FFMPEG_PATH}`",

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -216,6 +216,8 @@ class Loom:
         if self.parallel and frame_number is None:
             raise ValueError("frame_number must be provided when parallel=True")
 
+        assert self.frame_counter is not None
+
         if not self.parallel:
             frame_filepath = self.frames_directory / f"frame_{self.frame_counter:06d}.png"
             self.frame_counter += 1

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -217,9 +217,9 @@ class Loom:
         if self.parallel and frame_number is None:
             raise ValueError("frame_number must be provided when parallel=True")
 
-        assert self.frame_counter is not None
-
         if not self.parallel:
+            assert self.frame_counter is not None
+
             frame_filepath = self.frames_directory / f"frame_{self.frame_counter:06d}.png"
             self.frame_counter += 1
         else:

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -12,6 +12,8 @@ from IPython.display import Video, Image
 
 DEFAULT_FFMPEG_PATH = plt.rcParams['animation.ffmpeg_path']
 
+ACCEPTABLE_EXTENSIONS = ("mp4", "gif")
+
 class Loom:
     """
     A class for creating animations from matplotlib figures.
@@ -134,6 +136,11 @@ class Loom:
         if self.verbose:
             print(f"output_filepath: {self.output_filepath}")
             print(f"frames_directory: {self.frames_directory}")
+
+        if self.file_format not in ACCEPTABLE_EXTENSIONS:
+            raise ValueError("File Extension not Valid! "
+                             f"Must be one of: {ACCEPTABLE_EXTENSIONS}"
+                             )
 
     def __enter__(self) -> 'Loom':
         """
@@ -290,6 +297,8 @@ class Loom:
                 gif_filter = "split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse"
 
             command.extend(["-vf", gif_filter, str(self.output_filepath)])
+        else:
+            raise ValueError("Export File Format Not Valid!")
 
         PIPE = subprocess.PIPE
         process = subprocess.Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE)

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -21,7 +21,6 @@ else:
     DEFAULT_FFMPEG_PATH: str = plt.rcParams['animation.ffmpeg_path']
     os.environ[_LOOM_DEFAULT_ENVIRON_VAR] = DEFAULT_FFMPEG_PATH
 
-ACCEPTABLE_EXTENSIONS = ("mp4", "gif")
 
 class Loom:
     """
@@ -174,10 +173,6 @@ class Loom:
             print(f"output_filepath: {self.output_filepath}")
             print(f"frames_directory: {self.frames_directory}")
 
-        if self.file_format not in ACCEPTABLE_EXTENSIONS:
-            raise ValueError("File Extension not Valid! "
-                             f"Must be one of: {ACCEPTABLE_EXTENSIONS}"
-                             )
 
     def __enter__(self) -> 'Loom':
         """

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -129,7 +129,9 @@ class Loom:
             self.frames_directory = Path(frames_directory)
         
         # Allow providing of ffmpeg path to class instance
-        self.ffmpeg_path: str | None = None
+        self.ffmpeg_path: str = DEFAULT_FFMPEG_PATH
+
+        # Only throws an error if a path was provided
         if ffmpeg_path is not None:
             _ffmpeg_path = Path(ffmpeg_path)
 
@@ -148,15 +150,13 @@ class Loom:
                         f"path of `{DEFAULT_FFMPEG_PATH}`"
                     )
                     
-                    self.ffmpeg_path = DEFAULT_FFMPEG_PATH
-
                 # If path fallback is not enabled, raise an error
                 else:
                     raise FileNotFoundError(
                         f"Provided ffmpeg path of `{ffmpeg_path}` (resolving " +
                         f"to `{_ffmpeg_path}`) was not found!"
-                    )
-
+                    )            
+                
         # In theory this should never fail.
         assert isinstance(self.ffmpeg_path, str), "ffmpeg path is not a string?"
 

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -102,6 +102,7 @@ class Loom:
                 f"got {odd_dimension_handling}"
             )
         self.odd_dimension_handling: str = odd_dimension_handling
+        self._get_scale_filter() # Should throw value error if wrong
 
         if self.output_filepath.exists() and not self.overwrite:
             raise FileExistsError(
@@ -255,6 +256,8 @@ class Loom:
             return "crop='if(mod(iw,2),iw-1,iw)':'if(mod(ih,2),ih-1,ih)':0:0"
         elif self.odd_dimension_handling == "pad":
             return "pad='if(mod(iw,2),iw+1,iw)':'if(mod(ih,2),ih+1,ih)':0:0:color=white"
+        else:
+            raise ValueError("Scale Settings Incorrect!")
 
     def save_video(self) -> None:
         """

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -1,4 +1,4 @@
-import subprocess
+import subprocess, os
 import warnings
 
 from pathlib import Path
@@ -11,7 +11,15 @@ from matplotlib.figure import Figure
 
 from IPython.display import Video, Image
 
-DEFAULT_FFMPEG_PATH: str = plt.rcParams['animation.ffmpeg_path']
+
+# This should allow 
+_LOOM_DEFAULT_ENVIRON_VAR = "LOOM_FFMPEG_PATH"
+
+if _LOOM_DEFAULT_ENVIRON_VAR in os.environ:
+    DEFAULT_FFMPEG_PATH = os.environ[_LOOM_DEFAULT_ENVIRON_VAR]
+else:
+    DEFAULT_FFMPEG_PATH: str = plt.rcParams['animation.ffmpeg_path']
+    os.environ[_LOOM_DEFAULT_ENVIRON_VAR] = DEFAULT_FFMPEG_PATH
 
 ACCEPTABLE_EXTENSIONS = ("mp4", "gif")
 

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -10,7 +10,7 @@ from matplotlib.figure import Figure
 
 from IPython.display import Video, Image
 
-DEFAULT_FFMPEG_PATH = plt.rcParams['animation.ffmpeg_path']
+DEFAULT_FFMPEG_PATH: str = plt.rcParams['animation.ffmpeg_path']
 
 ACCEPTABLE_EXTENSIONS = ("mp4", "gif")
 

--- a/matplotloom/loom.py
+++ b/matplotloom/loom.py
@@ -128,7 +128,7 @@ class Loom:
             self.frames_directory = Path(frames_directory)
         
         # Allow providing of ffmpeg path to class instance
-        self.ffmpeg_path: str = DEFAULT_FFMPEG_PATH
+        self.ffmpeg_path: Path = Path(DEFAULT_FFMPEG_PATH)
 
         # Only throws an error if a path was provided
         if ffmpeg_path is not None:
@@ -138,7 +138,7 @@ class Loom:
             if _ffmpeg_path.exists():
                 # Store the absolute path as things can get a bit funky with
                 # path enrolment & multiprocessing.
-                self.ffmpeg_path = str(_ffmpeg_path.absolute())
+                self.ffmpeg_path = _ffmpeg_path.absolute()
 
             else:
                 # Otherwise check if path fallback is enabled & warn the user
@@ -157,7 +157,7 @@ class Loom:
                     )            
                 
         # In theory this should never fail.
-        assert isinstance(self.ffmpeg_path, str), "ffmpeg path is not a string?"
+        assert isinstance(self.ffmpeg_path, Path), "ffmpeg path is not a string?"
 
         # We don't use the frame counter in parallel mode.
         self.frame_counter: Optional[int] = 0 if not self.parallel else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "sphinx>=8.1.3",
 ]
 examples = [
+    "imageio-ffmpeg>=0.6.0",
     "cartopy>=0.24.1",
     "cmocean>=4.0.3",
     "joblib>=1.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "matplotloom"
-version = "0.9.1"
+version = "0.9.2"
 description = "Weave your frames into matplotlib animations."
 authors = [
     { name = "ali-ramadhan", email = "ali.hh.ramadhan@gmail.com" }


### PR DESCRIPTION
Changed default ffmpeg command to use matplotlib.pyplot.rcParams['animation.ffmpeg_path'] and added "ffmpeg_path" as a new argument to the Loom initialiser to allow for each Loom instance to have its own ffmpeg command path (defaults to matplotlib's).

Sorry for the double pull-request - I managed to mangle my git history.