### PR TITLE
Run tests every night

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Run nightly at 3 AM Mountain Time (10 AM UTC)
+    - cron: '0 10 * * *'
 
 jobs:
   ci:


### PR DESCRIPTION
This repo can go a while without running tests, so might be healthy to run them every night just in case they start to fail.